### PR TITLE
Save previous property value

### DIFF
--- a/src/ArrayHydrator.php
+++ b/src/ArrayHydrator.php
@@ -1,6 +1,7 @@
 <?php
 namespace pmill\Doctrine\Hydrator;
 
+use ArrayAccess;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -220,7 +221,15 @@ class ArrayHydrator
         $reflectionObject = new \ReflectionObject($entity);
         $values = is_array($value) ? $value : [$value];
 
+        $propertyRef = $reflectionObject->getProperty($propertyName);
+        $propertyRef->setAccessible(true);
+        $propertyValue = $propertyRef->getValue($entity);
+
         $assocationObjects = [];
+        if (is_array($propertyValue) || $propertyValue instanceof ArrayAccess) {
+            $assocationObjects = $propertyValue;
+        }
+
         foreach ($values as $value) {
             if (is_array($value)) {
                 $assocationObjects[] = $this->hydrate($mapping['targetEntity'], $value);

--- a/tests/fixtures/Tag.php
+++ b/tests/fixtures/Tag.php
@@ -1,0 +1,55 @@
+<?php
+namespace pmill\Doctrine\Hydrator\Test\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="tags")
+ */
+class Tag
+{
+    /**
+     * @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/fixtures/User.php
+++ b/tests/fixtures/User.php
@@ -1,6 +1,7 @@
 <?php
 namespace pmill\Doctrine\Hydrator\Test\Fixture;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -51,6 +52,20 @@ class User
      * @var Preference
      */
     protected $preference;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Tag", mappedBy="user")
+     * @var ArrayCollection
+     */
+    protected $tags;
+
+    /**
+     * Constructor of the class
+     */
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
 
     /**
      * @return int
@@ -162,5 +177,13 @@ class User
     public function setPreference($preference)
     {
         $this->preference = $preference;
+    }
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getTags()
+    {
+        return $this->tags;
     }
 }

--- a/tests/unit/ArrayHydratorTest.php
+++ b/tests/unit/ArrayHydratorTest.php
@@ -2,6 +2,7 @@
 
 namespace pmill\Doctrine\Hydrator\Test;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use Mockery as m;
 use pmill\Doctrine\Hydrator\ArrayHydrator;
@@ -262,5 +263,25 @@ class ArrayHydratorTest extends TestCase
         $this->assertInternalType('integer', $call->getDuration());
         $this->assertInstanceOf(\DateTime::class, $call->getStartTime());
         $this->assertInternalType('bool', $call->isStatus());
+    }
+
+    public function testOneToManySavePreviousPropertyValue()
+    {
+        $user = new Fixture\User();
+
+        $this->assertInstanceOf(ArrayCollection::class, $user->getTags());
+
+        $user = $this->hydrator->hydrate($user, ['tags' => [
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ]]);
+
+        $this->assertInstanceOf(ArrayCollection::class, $user->getTags());
+
+        $this->assertCount(2, $user->getTags());
+
+        $this->assertSame('foo', $user->getTags()[0]->getName());
+
+        $this->assertSame('bar', $user->getTags()[1]->getName());
     }
 }


### PR DESCRIPTION
I have an entity:

```php
use Doctrine\Common\Collections\ArrayCollection;

private $aliases;

public function __construct()
{
    $this->aliases = new ArrayCollection();
}

public function getAliases() : ArrayCollection
{
    return $this->aliases;
}
```

I hydrate the entity as follows:

```php
$brand = $hydrator->hydrate(\App\Entity\Brand::class, $request->getParsedBody());
```

And... the following error (incorrect behaviour):

```php
var_dump($brand->getAliases()); // returns array...
```

I fixed this problem, now it works as follows::

```php
var_dump($brand->getAliases()); // returns ArrayCollection...
```
